### PR TITLE
[Android] doc: Add how to build nnstreamer-based test app

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -69,12 +69,21 @@ as well as C/C++ JNI source code.  The 'ndk-build' command uses jni/Android.mk b
 However, the 'gradlew' command uses the 'build.gradle' file instead of the existing 'jni/Android.mk'.
 
 ```bash
-cd jni
-ndk-build
+git clone https://github.com/nnsuite/nnstreamer.git
+cd ./nnstreamer/jni
+ndk-build NDK_PROJECT_PATH=.  APP_BUILD_SCRIPT=./Android-nnstreamer.mk NDK_APPLICATION_MK=./Application.mk -j$(nproc)
 ```
 For more details, please refer to https://github.com/nnsuite/nnstreamer/tree/master/jni.
 
 
 ## Build NNstreamer-based test applications
- * TODO 
+In order to understand how developers implement a NNstreamer-based application,
+You can build simple test applications that is located in ./tests/ directory of the NNstreamer repository as following:
 
+```bash
+git clone https://github.com/nnsuite/nnstreamer.git
+cd ./nnstreamer/jni
+ndk-build NDK_PROJECT_PATH=.  APP_BUILD_SCRIPT=./Android-app.mk NDK_APPLICATION_MK=./Application.mk -j$(nproc)
+ls -al ../libs/arm64-v8a/
+
+```


### PR DESCRIPTION
This commit is to append how to build test application based on
NNstreamer library. It will be helpful to a developer that want to know
how to develop NNstreamer-based application on Android platform.

**Changes**
1. Updated the existing nnstreamer library build manual
2. Added how to build test applications

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>