### PR TITLE
[Android/ARM64] Deployment: Manipulating ELF files with patchelf

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -90,3 +90,22 @@ ls -al ../libs/arm64-v8a/
 ```
 
 For more details on test applications, please refer to https://github.com/nnsuite/nnstreamer/tree/master/tests
+
+## Experimental: Using patchelf to manipulate ELF files
+**Do NOT strip. It may corrupt 'patchelf'.**
+
+We sometimes meet a situation that have to manipulate the existing ELF binary files on the target device
+because some software vendors provide binary files only to protect their intelletual property.
+In this case, the '[patchelf](https://github.com/NixOS/patchelf)' package is helpful to us to modify
+the dynamic linker (ELF interpreter) and RPATH of ELF executables and libraries as an workaround.
+ * Change the dynamic loader ("ELF interpreter") of executables
+ * Change the RPATH of executables and libraries
+ * Remove declared dependencies on dynamic libraries (DT_NEEDED entries)
+
+If you use another distribution instead of Ubuntu, please visit https://pkgs.org/download/patchelf.
+
+```bash
+sudo apt install patchelf
+man patchelf
+```
+


### PR DESCRIPTION
We sometimes meet a situation that have to manipulate the existing ELF binary files on the target device
because some software vendors provide binary files only to protect their intellectual property.
In this case, the '[patchelf](https://github.com/NixOS/patchelf)' package is helpful to us to modify
the dynamic linker (ELF interpreter) and RPATH of ELF executables and libraries as an workaround.

* What for?
 * Change the dynamic loader ("ELF interpreter") of executables
 * Change the RPATH of executables and libraries
 * Remove declared dependencies on dynamic libraries (DT_NEEDED entries)

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>