### PR TITLE
[Meson] bugfix: Provide proper build dep for custom filter exmaples

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,9 @@ thread_dep = dependency('threads') # pthread for tensorflow-lite
 tf_dep = dependency('tensorflow', required: false)
 protobuf_dep = dependency('protobuf', version: '>= 3.4.0', required: false)
 
+# Dependency for custom filter examples
+nns_dep = dependency('nnstreamer', required: false)
+
 have_tensorflow = false
 if tf_dep.found() and protobuf_dep.found()
   have_tensorflow = true

--- a/native/example_speech_command_tensorflow_lite/meson.build
+++ b/native/example_speech_command_tensorflow_lite/meson.build
@@ -5,8 +5,10 @@ executable('nnstreamer_example_speech_command_tflite',
   install_dir: examples_install_dir
 )
 
+cf_flag = cc.has_header('nnstreamer/tensor_filter_custom.h') or nns_dep.found()
 library('nnscustom_speech_command_tflite',
   'nnscustom_speech_command_tflite.c',
-  install: true,
-  install_dir: examples_install_dir
+  install: cf_flag,
+  install_dir: examples_install_dir,
+  build_by_default: cf_flag
 )


### PR DESCRIPTION
Relates to https://github.com/nnsuite/nnstreamer/issues/1107.

In order to provide a proper build dependency on nnstreamer-dev for the examples implementing custom filters, this patch modifies meson build scripts.

Signed-off-by: Wook Song <wook16.song@samsung.com>

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped