### PR TITLE
Android: Update defaultconfig of build.gradle for google store

### DIFF
--- a/android/example_app/nnstreamer-multi/build.gradle
+++ b/android/example_app/nnstreamer-multi/build.gradle
@@ -4,9 +4,9 @@ android {
     compileSdkVersion 24
     buildToolsVersion '28.0.3'
     defaultConfig {
-        applicationId "org.freedesktop.gstreamer.nnstreamer"
+        applicationId "org.freedesktop.gstreamer.nnstreamer.multi"
         minSdkVersion 24
-        targetSdkVersion 24
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 

--- a/android/example_app/nnstreamer-ssd/build.gradle
+++ b/android/example_app/nnstreamer-ssd/build.gradle
@@ -4,9 +4,9 @@ android {
     compileSdkVersion 24
     buildToolsVersion '28.0.3'
     defaultConfig {
-        applicationId "org.freedesktop.gstreamer.nnstreamer"
+        applicationId "org.freedesktop.gstreamer.nnstreamer.ssd"
         minSdkVersion 24
-        targetSdkVersion 24
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
This commit is to update the existing "defaultconfig" block in build.gradle
file for registering the applications at Google Store.

**Changelog**
   - Changed 'minSdkVersion' from 24 to 26
   - Keep the unique 'applicationId'

Signed-off-by: Geunsik Lim <geunsik.lim@samsung.com>


---