### PR TITLE
[Dist/Debian] Add explicit dependency on ninja >= 1.5

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: nnstreamer-example
 Maintainer: MyungJoo Ham <myungjoo.ham@samsung.com>
 Build-Depends:
- debhelper (>=9), meson (>=0.40),
+ debhelper (>=9), meson (>=0.40), ninja-build (>=1.5),
  libglib2.0-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev,
  gstreamer1.0-plugins-base, gstreamer1.0-plugins-good,
  nnstreamer, nnstreamer-dev,


### PR DESCRIPTION
This tries to resolve:

ERROR: Could not detect Ninja v1.5 or newer

of nnstreamer-example build.


This is expected to eliminate CI errors of #57, #58 after rebase.

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>


