### PR TITLE
[CodeClean] unify the behavior that appears when there is no appropriate model

### DIFF
--- a/native/example_decoder_image_labelling/nnstreamer_example_decoder_image_labelling.c
+++ b/native/example_decoder_image_labelling/nnstreamer_example_decoder_image_labelling.c
@@ -120,7 +120,7 @@ _tflite_init_info (tflite_info_s * tflite_info, const gchar * path)
   tflite_info->model_path = g_strdup_printf ("%s/%s", path, tflite_model);
 
   if (access (tflite_info->model_path, F_OK) != 0) {
-    _print_log ("cannot find tflite model [%s]", tflite_info->model_path);
+    g_critical ("cannot find tflite model [%s]", tflite_info->model_path);
     return FALSE;
   }
 

--- a/native/example_image_classification_caffe2/nnstreamer_example_image_classification_caffe2.c
+++ b/native/example_image_classification_caffe2/nnstreamer_example_image_classification_caffe2.c
@@ -144,13 +144,13 @@ _caffe2_init_info (caffe2_info_s * caffe2_info, const gchar * path)
       g_strdup_printf ("%s/%s", path, caffe2_pred_model);
 
   if (access (caffe2_info->init_model_path, F_OK) != 0) {
-    _print_log ("cannot find caffe2 init model [%s]",
+    g_critical ("cannot find caffe2 init model [%s]",
         caffe2_info->init_model_path);
     return FALSE;
   }
 
   if (access (caffe2_info->pred_model_path, F_OK) != 0) {
-    _print_log ("cannot find caffe2 predict model [%s]",
+    g_critical ("cannot find caffe2 predict model [%s]",
         caffe2_info->pred_model_path);
     return FALSE;
   }
@@ -175,7 +175,7 @@ _caffe2_init_info (caffe2_info_s * caffe2_info, const gchar * path)
 
     fclose (fp);
   } else {
-    _print_log ("cannot find caffe2 label [%s]", caffe2_info->label_path);
+    g_critical ("cannot find caffe2 label [%s]", caffe2_info->label_path);
     return FALSE;
   }
 

--- a/native/example_image_classification_tflite/nnstreamer_example_image_classification_tflite.c
+++ b/native/example_image_classification_tflite/nnstreamer_example_image_classification_tflite.c
@@ -139,7 +139,7 @@ _tflite_init_info (tflite_info_s * tflite_info, const gchar * path)
   tflite_info->model_path = g_strdup_printf ("%s/%s", path, tflite_model);
 
   if (access (tflite_info->model_path, F_OK) != 0) {
-    _print_log ("cannot find tflite model [%s]", tflite_info->model_path);
+    g_critical ("cannot find tflite model [%s]", tflite_info->model_path);
     return FALSE;
   }
 
@@ -163,7 +163,7 @@ _tflite_init_info (tflite_info_s * tflite_info, const gchar * path)
 
     fclose (fp);
   } else {
-    _print_log ("cannot find tflite label [%s]", tflite_info->label_path);
+    g_critical ("cannot find tflite label [%s]", tflite_info->label_path);
     return FALSE;
   }
 

--- a/native/example_object_detection_tensorflow/nnstreamer_example_object_detection_tf.cc
+++ b/native/example_object_detection_tensorflow/nnstreamer_example_object_detection_tf.cc
@@ -165,11 +165,11 @@ tf_init_info (TFModelInfo * tf_info, const gchar * path)
   tf_info->labels = NULL;
 
   if (!g_file_test (tf_info->model_path, G_FILE_TEST_IS_REGULAR)) {
-    g_critical ("the file of model_path is not valid: %s\n", tf_info->model_path);
+    g_critical ("cannot find tf model [%s]", tf_info->model_path);
     return FALSE;
   }
   if (!g_file_test (tf_info->label_path, G_FILE_TEST_IS_REGULAR)) {
-    g_critical ("the file of label_path is not valid: %s\n", tf_info->label_path);
+    g_critical ("cannot find tf label [%s]", tf_info->label_path);
     return FALSE;
   }
 

--- a/native/example_object_detection_tensorflow_lite/nnstreamer_example_object_detection_tflite.cc
+++ b/native/example_object_detection_tensorflow_lite/nnstreamer_example_object_detection_tflite.cc
@@ -222,15 +222,15 @@ tflite_init_info (TFLiteModelInfo * tflite_info, const gchar * path)
   tflite_info->labels = NULL;
 
   if (!g_file_test (tflite_info->model_path, G_FILE_TEST_IS_REGULAR)) {
-    g_critical ("the file of model_path is not valid: %s\n", tflite_info->model_path);
+    g_critical ("cannot find tflite model [%s]", tflite_info->model_path);
     return FALSE;
   }
   if (!g_file_test (tflite_info->label_path, G_FILE_TEST_IS_REGULAR)) {
-    g_critical ("the file of label_path is not valid%s\n", tflite_info->label_path);
+    g_critical ("cannot find tflite label [%s]", tflite_info->label_path);
     return FALSE;
   }
   if (!g_file_test (tflite_info->box_prior_path, G_FILE_TEST_IS_REGULAR)) {
-    g_critical ("the file of box_prior_path is not valid%s\n", tflite_info->box_prior_path);
+    g_critical ("cannot find tflite box_prior [%s]", tflite_info->box_prior_path);
     return FALSE;
   }
 

--- a/native/example_speech_command_tensorflow_lite/nnstreamer_example_speech_command_tflite.c
+++ b/native/example_speech_command_tensorflow_lite/nnstreamer_example_speech_command_tflite.c
@@ -127,7 +127,7 @@ tflite_init_info (tflite_info_s * tflite_info, const gchar * path)
   tflite_info->model_path = g_strdup_printf ("%s/%s", path, tflite_model);
 
   if (access (tflite_info->model_path, F_OK) != 0) {
-    _print_log ("cannot find tflite model [%s]", tflite_info->model_path);
+    g_critical ("cannot find tflite model [%s]", tflite_info->model_path);
     return FALSE;
   }
 
@@ -151,7 +151,7 @@ tflite_init_info (tflite_info_s * tflite_info, const gchar * path)
 
     fclose (fp);
   } else {
-    _print_log ("cannot find tflite label [%s]", tflite_info->label_path);
+    g_critical ("cannot find tflite label [%s]", tflite_info->label_path);
     return FALSE;
   }
 

--- a/native/example_two_tensor_stream/nnstreamer_example_two_tensor_stream.c
+++ b/native/example_two_tensor_stream/nnstreamer_example_two_tensor_stream.c
@@ -149,7 +149,7 @@ _tflite_init_info (tflite_info_s * tflite_info, const gchar * path,
   tflite_info->model_path = g_strdup_printf ("%s/%s", path, tflite_model);
 
   if (access (tflite_info->model_path, F_OK) != 0) {
-    _print_log ("cannot find tflite model [%s]", tflite_info->model_path);
+    g_critical ("cannot find tflite model [%s]", tflite_info->model_path);
     return FALSE;
   }
 
@@ -173,7 +173,7 @@ _tflite_init_info (tflite_info_s * tflite_info, const gchar * path,
 
     fclose (fp);
   } else {
-    _print_log ("cannot find tflite label [%s]", tflite_info->label_path);
+    g_critical ("cannot find tflite label [%s]", tflite_info->label_path);
     return FALSE;
   }
 


### PR DESCRIPTION
1. set logging level to g_critical().
2. unify the error messsages.

related issue: #60 

Signed-off-by: Junsang Mo <junsang.mo@samsung.com>