### PR TITLE
Template for tensor_filter static in/out dims.

### DIFF
--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,24 @@
+# Template Codes for Subplugins of NNStreamer
+  
+## What is subplugin?
+
+
+- NNStreamer's elements (e.g., ```tensor_filter``` and ```tensor_decoder```) are already plugins of GStreamer. Thus, the plugins for such plugins are called subplugins; e.g., ```tensorflow-lite``` subplugin of ```tensor_filter```.
+
+## Description of provided templates
+
+- [tensor_filter_subplugin](tensor_filter_subplugin): Subplugin template of a standard tensor_filter with static input and output tensor dimensions.
+    - Execute ```tensor_fiter_subplugin/$ deploy.sh [name] [deploy-path]``` to create a new git repo based on the template code.
+    - Packaging file for Tizen (>= 5.5 M2) is provided.
+    - Example:
+
+```
+tensor_filter_subplugin$ deploy sample /tmp/X/
+..
+..
+tensor_filter_subplugin$ cd /tmp/X/
+/tmp/X/$ gbs build
+..
+..
+/tmp/X/$
+```

--- a/templates/tensor_filter_subplugin/deploy.sh
+++ b/templates/tensor_filter_subplugin/deploy.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+##
+## @file deploy.sh
+## @author MyungJoo Ham <myungjoo.ham@gmail.com>
+## @date Oct 11 2019
+## @brief This creates a new git repo with the given template.
+TARGET=$(pwd)
+BASEPATH=`dirname "$0"`
+BASENAME=`basename "$0"`
+
+
+if [[ $# -lt 2 ]]
+then
+	printf "usage: ${BASENAME} <name> <path to create>\n\n"
+	printf "    This creates a new git repo at <path to create> with the\n"
+	printf "  template code for a tensor-filter subplugin, \"<name>\"\n\n"
+	exit 1
+fi
+
+name="$1"
+path="$2"
+
+regex="\W"
+if [[ $name =~ $regex ]]
+then
+	printf "The name \"$1\" contains a whitespace. Cannot proceed.\n\n"
+	exit 1
+fi
+regex="^[a-zA-Z0-9_\-]+$"
+if [[ ! $name =~ $regex ]]
+then
+	printf "Please provide name with A-Z, a-z, -, _, 0-9 only. The name \"$1\" is not such a name. Cannot proceed.\n\n"
+	exit 1
+fi
+
+
+if [ -e $2 ]
+then
+	printf "The path $2 already exists. Please designate a new path.\n\n"
+	exit 1
+fi
+
+mkdir -p $2
+if [ ! -d $2 ]
+then
+	printf "Failed to create a new directory $2.\n\n"
+	exit 1
+fi
+
+printf "Initializing a git repo of tensor-filter at $2.\n"
+pushd $2
+git init
+popd
+
+cp -R src packaging meson.build $2/
+
+pushd $2
+
+pushd packaging
+mv tensor-filter-TEMPLATE.manifest tensor-filter-${name}.manifest
+mv tensor-filter-TEMPLATE.spec.in tensor-filter-${name}.spec
+
+sed -i "s|TEMPLATE|${name}|" tensor-filter-${name}.spec
+popd
+sed -i "s|TEMPLATE|${name}|" meson.build
+sed -i "s|TEMPLATE|${name}|" src/tensor_filter_subplugin.c
+
+git add meson.build src/*.c packaging/*
+git commit -m "Initial Tensor-Filter Subplugin Code of ${name}" -m "This is the template code of nnstreamer tensor_filter subplugin"
+popd

--- a/templates/tensor_filter_subplugin/meson.build
+++ b/templates/tensor_filter_subplugin/meson.build
@@ -1,0 +1,32 @@
+project('nnstreamer', 'c',
+  version: '1.0.0',
+  license: ['Proprietary'],
+  meson_version: '>=0.42.0',
+)
+
+cc = meson.get_compiler('c')
+
+path_prefix = get_option('prefix')
+subplugin_install_prefix = join_paths(path_prefix, 'lib', 'nnstreamer')
+filter_subplugin_install_dir = join_paths(subplugin_install_prefix, 'filters')
+
+glib_dep = dependency('glib-2.0')
+gobject_dep = dependency('gobject-2.0')
+nnstreamer_dep = dependency('nnstreamer')
+
+base_deps = [
+  glib_dep,
+  gobject_dep,
+  nnstreamer_dep
+]
+
+sources = [
+  'src/tensor_filter_subplugin.c'
+]
+
+subplugin_shared = shared_library('TEMPLATE',
+  sources,
+  dependencies: base_deps,
+  install: true,
+  install_dir: filter_subplugin_install_dir
+)

--- a/templates/tensor_filter_subplugin/packaging/tensor-filter-TEMPLATE.manifest
+++ b/templates/tensor_filter_subplugin/packaging/tensor-filter-TEMPLATE.manifest
@@ -1,0 +1,5 @@
+<manifest>
+ <request>
+    <domain name="_"/>
+ </request>
+</manifest>

--- a/templates/tensor_filter_subplugin/packaging/tensor-filter-TEMPLATE.spec.in
+++ b/templates/tensor_filter_subplugin/packaging/tensor-filter-TEMPLATE.spec.in
@@ -1,0 +1,42 @@
+Name:		tensor-filter-TEMPLATE
+Summary:	NNStreamer tensor-filter subplugin for TEMPLATE
+Version:	1.0.0
+Release:	0
+Group:		Development/Libraries
+Packager:	MyungJoo Ham <myungjoo.ham@samsung.com>
+# You may change the License to anything you want (Proprietary is allowed)
+License:	Proprietary
+Source0:	tensor-filter-TEMPLATE-%{version}.tar.gz
+Source1001:	tensor-filter-TEMPLATE.manifest
+
+Requires:	nnstreamer
+BuildRequires:	nnstreamer-devel
+BuildRequires:	meson
+BuildRequires:	glib2-devel
+
+%description
+Fill this in!
+
+%prep
+%setup -q
+cp %{SOURCE1001} .
+
+%build
+mkdir -p build
+meson --prefix=%{_prefix} build
+ninja -C build %{?_smp_mflags}
+
+%install
+DESTDIR=%{buildroot} ninja -C build %{?_smp_mflags} install
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
+
+%files
+%manifest tensor-filter-TEMPLATE.manifest
+%defattr(-,root,root,-)
+%{_prefix}/lib/nnstreamer/filters/*.so
+
+%changelog
+* Fri Oct 11 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+- Initial Template Tensor-Filter of 1.0.0

--- a/templates/tensor_filter_subplugin/src/tensor_filter_subplugin.c
+++ b/templates/tensor_filter_subplugin/src/tensor_filter_subplugin.c
@@ -1,0 +1,152 @@
+/**
+ * GStreamer Tensor_Filter TEMPLATE Code
+ * Copyright (C) 2019 MyungJoo Ham <myungjoo.ham@samsung.com>
+ *
+ * This is a template with no license requirements.
+ * Writers may alter the license to anything they want.
+ * The author hereby allows to do so.
+ */
+/**
+ * @file	tensor_filter_subplugin.c
+ * @date	11 Oct 2019
+ * @brief	NNStreamer tensor-filter subplugin template
+ * @see		http://github.com/nnsuite/nnstreamer
+ * @author	MyungJoo Ham <myungjoo.ham@samsung.com>
+ * @bug		No known bugs
+ */
+
+#include <string.h>
+#include <glib.h>
+#include <nnstreamer_plugin_api_filter.h>
+
+void init_filter_TEMPLATE (void) __attribute__ ((constructor));
+void fini_filter_TEMPLATE (void) __attribute__ ((destructor));
+
+/**
+ * @brief If you need to store session or model data,
+ *        this is what you want to fill in.
+ */
+typedef struct
+{
+  gchar *model_path; /**< This is a sample. You may remove/change it */
+} TEMPLATE_pdata;
+
+static void TEMPLATE_close (const GstTensorFilterProperties * prop,
+    void **private_data);
+
+/**
+ * @brief The standard tensor_filter callback
+ */
+static int
+TEMPLATE_open (const GstTensorFilterProperties * prop, void **private_data)
+{
+  int err = 0;
+  TEMPLATE_pdata *pdata;
+
+  if (*private_data != NULL) {
+    pdata = *private_data;
+    if (strcmp (prop->model_file, pdata->model_path)) {
+      TEMPLATE_close (prop, private_data);  /* "reopen" */
+    } else {
+      return 1;
+    }
+  }
+
+  pdata = g_new0 (TEMPLATE_pdata, 1);
+  if (pdata == NULL)
+    return -1;
+
+  *private_data = (void *) pdata;
+
+  /** @todo Initialize your own framework or hardware here */
+
+  pdata->model_path = g_strdup (prop->model_file);
+
+  return err;
+}
+
+/**
+ * @brief The standard tensor_filter callback
+ */
+static void
+TEMPLATE_close (const GstTensorFilterProperties * prop, void **private_data)
+{
+  TEMPLATE_pdata *pdata;
+  pdata = *private_data;
+
+  /** @todo Close what you have opened/allocated with TEMPLATE_open */
+
+  g_free (pdata->model_path);
+  pdata->model_path = NULL;
+
+  g_free (pdata);
+  *private_data = NULL;
+}
+
+/**
+ * @brief The standard tensor_filter callback for static input/output dimension.
+ * @note If you want to support flexible/dynamic input/output dimension,
+ *       read nnstreamer_plugin_api_filter.h and supply the
+ *       setInputDimension callback.
+ */
+static int
+TEMPLATE_getInputDim (const GstTensorFilterProperties * prop,
+    void **private_data, GstTensorsInfo * info)
+{
+  /** @todo Configure info with the proper (static) input tensor dimension */
+  return 0;
+}
+
+/**
+ * @brief The standard tensor_filter callback for static input/output dimension.
+ * @note If you want to support flexible/dynamic input/output dimension,
+ *       read nnstreamer_plugin_api_filter.h and supply the
+ *       setInputDimension callback.
+ */
+static int
+TEMPLATE_getOutputDim (const GstTensorFilterProperties * prop,
+    void **private_data, GstTensorsInfo * info)
+{
+  /** @todo Configure info with the proper (static) output tensor dimension */
+  return 0;
+}
+
+/**
+ * @brief The standard tensor_filter callback
+ */
+static int
+TEMPLATE_invoke (const GstTensorFilterProperties * prop,
+    void **private_data, const GstTensorMemory * input,
+    GstTensorMemory * output)
+{
+  /** @todo Call your framework/hardware with the given input. */
+  return 0;
+}
+
+static gchar filter_subplugin_TEMPLATE[] = "TEMPLATE";
+
+static GstTensorFilterFramework NNS_support_TEMPLATE = {
+  .name = filter_subplugin_TEMPLATE,
+  .allow_in_place = FALSE,
+  .allocate_in_invoke = FALSE,
+  .run_without_model = FALSE,
+  .invoke_NN = TEMPLATE_invoke,
+  .getInputDimension = TEMPLATE_getInputDim,
+  .getOutputDimension = TEMPLATE_getOutputDim,
+  .open = TEMPLATE_open,
+  .close = TEMPLATE_close,
+};
+
+/**@brief Initialize this object for tensor_filter subplugin runtime register */
+void
+init_filter_TEMPLATE (void)
+{
+  nnstreamer_filter_probe (&NNS_support_TEMPLATE);
+}
+
+/** @brief Destruct the subplugin */
+void
+fini_filter_TEMPLATE (void)
+{
+  nnstreamer_filter_exit (NNS_support_TEMPLATE.name);
+}


### PR DESCRIPTION
This is a template & code-gen for tensor_filter
static in/out tensor dimension subplugin.

Use deploy.sh in the given path to start
your own tensor-filter subplugin code.

To use the template:

1. Go to the template directory
```
$ cd templates/tensor_filter_subplugin
```

2. Deploy (create a new git repo for your subplugin)
```
$ deploy ${NAME} ${GIT_PATH}
$ # Then you have your template code placed at ${GIT_PATH}
$ cd ${GIT_PATH}
${GIT_PATH}$ # here, you can try gbs build.
${GIT_PATH}$ gbs build
...
${GIT_PATH}$ # You get an "empty" tensor-filter subplugin as a Tizen rpm package.
```

3. Write your subplugin with the template
```
${GIT_PATH}$ vi src/tensor_filter_subplugin.c
```

4. Now you are ready to go!

Signed-off-by: MyungJoo Ham <myungjoo.ham@samsung.com>

This resolves the second part of https://github.com/nnsuite/nnstreamer/issues/1746
