### PR TITLE
Correct typo in README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NNStreamer Examples
 
-This repository shows developers how to create their applications with nnstreamer/gstreamer. We recommend to install nnstreamer by downloading prebuilt binary packages from Launchpad/PPA (Ubuntu) or Download.Tizen.org (Tizen). If you want to build nnstreamer in your system for your example application builds, pdebuild (Ubuntu) with PPA or gbs (Tizen) are recommended for building nnstreamer. This repository has been detached from nnstreamer.git to build examples independently from the nnstreamer souce code since Jan-09-2019.
+This repository shows developers how to create their applications with nnstreamer/gstreamer. We recommend to install nnstreamer by downloading prebuilt binary packages from Launchpad/PPA (Ubuntu) or Download.Tizen.org (Tizen). If you want to build nnstreamer in your system for your example application builds, pdebuild (Ubuntu) with PPA or gbs (Tizen) are recommended for building nnstreamer. This repository has been detached from nnstreamer.git to build examples independently from the nnstreamer source code since Jan-09-2019.
 
 Ubuntu PPA: nnstreamer/ppa [[PPA Main](https://launchpad.net/~nnstreamer/+archive/ubuntu/ppa)]<br />
 Tizen Project: devel:AIC:Tizen:5.0:nnsuite [[OBS Project](https://build.tizen.org/project/show/devel:AIC:Tizen:5.0:nnsuite)] [[RPM Repo](http://download.tizen.org/live/devel%3A/AIC%3A/Tizen%3A/5.0%3A/nnsuite/standard/)]

--- a/android/README.md
+++ b/android/README.md
@@ -69,10 +69,10 @@ For more details, please refer to the below websites.
  * https://github.com/centricular/cerbero-docs/blob/master/start.md
 
 ## Build NNstreamer full source with ndk-build
-We recommend that you read a Android NDK manual at https://developer.android.com/studio/build/building-cmdline.
+We recommend that you read an Android NDK manual at https://developer.android.com/studio/build/building-cmdline.
 If you have to compile just C/C++ source code for Android platform, please use 'ndk-build' command.
 Note that You must use 'gradlew' command on the Ubuntu terminal, if you have to compile JNI-based Java source code
-as well as C/C++ JNI source code.  The 'ndk-build' command uses jni/Android.mk by dfault.
+as well as C/C++ JNI source code.  The 'ndk-build' command uses jni/Android.mk by default.
 However, the 'gradlew' command uses the 'build.gradle' file instead of the existing 'jni/Android.mk'.
 
 ```bash


### PR DESCRIPTION
This patch fixes typo in README.md
souce -> source, dfault -> default

Signed-off-by: Junsang Mo <junsang.mo@samsung.com>