### PR TITLE
[Bash/Sample] Bash script example for tflite image segmentation @open sesame 11/15 15:43

### DIFF
--- a/bash_script/example_image_segmentation_tensorflow_lite/gst-launch-image-segmentation-tflite.sh
+++ b/bash_script/example_image_segmentation_tensorflow_lite/gst-launch-image-segmentation-tflite.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+gst-launch-1.0 -v \
+      videomixer name=mix sink_0::alpha=0.7 sink_1::alpha=0.6 ! videoconvert ! autovideosink \
+      v4l2src ! decodebin ! videoconvert ! videoscale ! \
+      video/x-raw,format=RGB,width=257,height=257 ! tee name=t \
+      t. ! queue ! mix. \
+      t. ! queue ! tensor_converter ! \
+      tensor_transform mode=arithmetic option=typecast:float32,div:255.0 ! \
+      tensor_filter framework=tensorflow-lite model=tflite_img_segment_model/deeplabv3_257_mv_gpu.tflite ! \
+      tensor_decoder mode=image_segment option1=tflite-deeplab ! mix.

--- a/bash_script/example_image_segmentation_tensorflow_lite/meson.build
+++ b/bash_script/example_image_segmentation_tensorflow_lite/meson.build
@@ -1,0 +1,4 @@
+install_data(['gst-launch-image-segmentation-tflite.sh'],
+  install_dir: examples_install_dir
+)
+

--- a/bash_script/meson.build
+++ b/bash_script/meson.build
@@ -4,6 +4,7 @@ endif
 
 if have_tensorflow_lite
   subdir('example_object_detection_tensorflow_lite')
+  subdir('example_image_segmentation_tensorflow_lite')
 endif
 
 subdir('example_models')


### PR DESCRIPTION
Related to #69

This PR contains two commits.
 1. Bash script example for tflite image segmentation
 -  It gets image from webcam and paints regions of objects detected. (* webcam is necessary)
 2. Meson build for tflite image segmentation example
 - Change related `meson build` for example

Signed-off-by: niklasjang niklasjang@gmail.com
Signed-off-by: Jihoon Lee ulla4571@gmail.com