### PR TITLE
dimension to handle text input

### DIFF
--- a/Tizen.native/SingleSample/src/nnstreamer-sample-single.c
+++ b/Tizen.native/SingleSample/src/nnstreamer-sample-single.c
@@ -52,7 +52,7 @@ nns_single_initialize (appdata_s * ad)
    *
    * tensor info (mobilenet_v1_1.0_224_quant.tflite)
    * input[0] >> type:5 (uint8), dim[3:224:224:1] video stream (RGB 224x224)
-   * output[0] >> type:5 (uint8), dim[1001:1:1:1] LABEL_SIZE
+   * output[0] >> type:5 (uint8), dim[1001:1] LABEL_SIZE
    */
   snprintf (test_model, 512, "%s%s", shared_path,
       "mobilenet_v1_1.0_224_quant.tflite");

--- a/native/example_sink/nnstreamer_sink_example.c
+++ b/native/example_sink/nnstreamer_sink_example.c
@@ -288,7 +288,7 @@ _test_src_timer_cb (gpointer user_data)
         return FALSE;
       }
 
-      text_data = g_strdup_printf ("example for text [%d/20]", buffer_index);
+      text_data = g_strdup_printf ("example for text [%02d/20]", buffer_index);
       buf = gst_buffer_new_wrapped (text_data, strlen (text_data));
 
       GST_BUFFER_PTS (buf) = 20 * GST_MSECOND * buffer_index;
@@ -335,11 +335,11 @@ _test_pipeline (test_media_type type)
       break;
 
     case TEST_TYPE_TEXT:
-      /* text 20 buffers */
+      /* text 20 buffers, you should denote the buffer size with the property input-dim in converter */
       str_pipeline =
           g_strdup_printf
-          ("appsrc name=appsrc caps=text/x-raw,format=utf8 ! "
-          "tensor_converter ! tensor_sink name=tensor_sink");
+          ("appsrc name=appsrc ! text/x-raw,format=utf8 ! "
+          "tensor_converter input-dim=24 ! tensor_sink name=tensor_sink");
       break;
 
     default:


### PR DESCRIPTION
update example to set the dimension for text input.
developer should set the input byte size of text input with the property input-dim.

Signed-off-by: Jaeyun Jung <jy1210.jung@samsung.com>
