### PR TITLE
[Tizen.platform] fix the Requires of vivante sample apps

### DIFF
--- a/Tizen.platform/Vivante_pipeline_NonGUI_inceptionV3/README.md
+++ b/Tizen.platform/Vivante_pipeline_NonGUI_inceptionV3/README.md
@@ -11,20 +11,20 @@ After gbs build and install at your target, you can execute it with below comman
 $ vivante-inceptionv3-pipeline ${PATH_TO_NB_FILE} ${PATH_TO_SO_FILE} ${PATH_TO_JPEG}
 # e.g. $ vivante-inceptionv3-pipeline \
 > /usr/share/dann/inception-v3.nb \
-> /usr/lib/nnstreamer/filters/libinceptionv3.so \
-> /usr/share/vivante-inceptionv3-pipeline/sample_pizza_299x299.jpg
+> /usr/share/vivante/inceptionv3/libinceptionv3.so \
+> /usr/share/vivante/res/sample_pizza_299x299.jpg
 ```
 
 The result should be similar with below
 ```bash
 root@localhost:~# vivante-inceptionv3-pipeline \
 > /usr/share/dann/inception-v3.nb \
-> /usr/lib/nnstreamer/filters/libinceptionv3.so \
-> /usr/share/vivante-inceptionv3-pipeline/sample_pizza_299x299.jpg 
+> /usr/share/vivante/inceptionv3/libinceptionv3.so \
+> /usr/share/vivante/res/sample_pizza_299x299.jpg 
 
 MODEL_NB path: /usr/share/dann/inception-v3.nb
-MODEL_SO path: /usr/lib/nnstreamer/filters/libinceptionv3.so
-IMAGE path: /usr/share/vivante-inceptionv3-pipeline/sample_pizza_299x299.jpg
+MODEL_SO path: /usr/share/vivante/inceptionv3/libinceptionv3.so
+IMAGE path: /usr/share/vivante/res/sample_pizza_299x299.jpg
 [146] pipeline: filesrc location="/usr/share/vivante-inceptionv3-pipeline/sample_pizza_299x299.jpg" blocksize=-1 ! jpegdec ! videoconvert ! video/x-raw,fox
 D [setup_node:368]Setup node id[0] uid[0] op[NBG]
 D [print_tensor:136]in(0) : id[   1] vtl[0] const[0] shape[ 3, 299, 299, 1   ] fmt[u8 ] qnt[ASM zp=128, scale=0.007812]

--- a/Tizen.platform/Vivante_pipeline_NonGUI_inceptionV3/packaging/vivante-inceptionv3-pipeline.spec
+++ b/Tizen.platform/Vivante_pipeline_NonGUI_inceptionV3/packaging/vivante-inceptionv3-pipeline.spec
@@ -9,7 +9,7 @@ Source0:	%{name}-%{version}.tar.gz
 Source1001:	%{name}.manifest
 
 Requires:	nnstreamer-vivante
-Requires:	vivante-nnstreamer-filter-inceptionv3
+Requires:	vivante-neural-network-models
 BuildRequires:	glib2-devel
 BuildRequires:  capi-base-common-devel
 BuildRequires:	pkgconfig(nnstreamer)
@@ -28,14 +28,14 @@ gcc src/main.c -o %{name} -lglib-2.0 -lcapi-nnstreamer
 
 %install
 mkdir -p %{buildroot}%{_bindir}
-mkdir -p %{buildroot}%{_datadir}/%{name}
+mkdir -p %{buildroot}%{_datadir}/vivante/res
 install -m 755 %{name} %{buildroot}%{_bindir}/%{name}
-install -m 644 res/sample_pizza_299x299.jpg %{buildroot}%{_datadir}/%{name}/sample_pizza_299x299.jpg
+install -m 644 res/sample_pizza_299x299/jpg %{buildroot}%{_datadir}/vivante/res/sample_pizza_299x299.jpg
 
 %files
 %manifest %{name}.manifest
 %{_bindir}/%{name}
-%{_datadir}/%{name}/sample_pizza_299x299.jpg
+%{_datadir}/vivante/res/sample_pizza_299x299.jpg
 
 %changelog
 * Tue Feb 18 2020 HyoungJoo Ahn <hello.ahn@samsung.com>

--- a/Tizen.platform/Vivante_single_NonGUI_inceptionV3/README.md
+++ b/Tizen.platform/Vivante_single_NonGUI_inceptionV3/README.md
@@ -11,8 +11,8 @@ After gbs build and install at your target, you can execute it with below comman
 $ vivante-inceptionv3-single ${PATH_TO_NB_FILE} ${PATH_TO_SO_FILE} ${PATH_TO_INPUT_FILE}
 # e.g. $ vivante-inceptionv3-single \
 > /usr/share/dann/inception-v3.nb \
-> /usr/lib/nnstreamer/filters/libinceptionv3.so \
-> /usr/share/vivante-inceptionv3-single/sample_pizza_299x299
+> /usr/share/vivante/inceptionv3/libinceptionv3.so \
+> /usr/share/vivante/res/sample_pizza_299x299
 ```
 
 If you don't have input(bytestream) file, you can make it with this command
@@ -24,12 +24,12 @@ The result should be similar with below
 ```bash
 root@localhost:~# vivante-inceptionv3-single \
 > /usr/share/dann/inception-v3.nb \
-> /usr/lib/nnstreamer/filters/libinceptionv3.so \
-> /usr/share/vivante-inceptionv3-single/sample_pizza_299x299
+> /usr/share/vivante/inceptionv3/libinceptionv3.so \
+> /usr/share/vivante/res/sample_pizza_299x299
 
 MODEL_NB path: /usr/share/dann/inception-v3.nb
-MODEL_SO path: /usr/lib/nnstreamer/filters/libinceptionv3.so
-FILE path: /usr/share/vivante-inceptionv3-single/sample_pizza_299x299
+MODEL_SO path: /usr/share/vivante/inceptionv3/libinceptionv3.so
+FILE path: /usr/sharevivante/res/sample_pizza_299x299
 D [setup_node:368]Setup node id[0] uid[0] op[NBG]
 D [print_tensor:136]in(0) : id[   1] vtl[0] const[0] shape[ 3, 299, 299, 1   ] fmt[u8 ] qnt[ASM zp=128, scale=0.007812]
 D [print_tensor:136]out(0): id[   0] vtl[0] const[0] shape[ 5, 1             ] fmt[f16] qnt[NONE]

--- a/Tizen.platform/Vivante_single_NonGUI_inceptionV3/packaging/vivante-inceptionv3-single.spec
+++ b/Tizen.platform/Vivante_single_NonGUI_inceptionV3/packaging/vivante-inceptionv3-single.spec
@@ -9,7 +9,7 @@ Source0:	%{name}-%{version}.tar.gz
 Source1001:	%{name}.manifest
 
 Requires:	nnstreamer-vivante
-Requires:	vivante-nnstreamer-filter-inceptionv3
+Requires:	vivante-neural-network-models
 BuildRequires:	glib2-devel
 BuildRequires:  capi-base-common-devel
 BuildRequires:	pkgconfig(nnstreamer)
@@ -28,14 +28,14 @@ gcc src/main.c -o %{name} -lglib-2.0 -lcapi-nnstreamer
 
 %install
 mkdir -p %{buildroot}%{_bindir}
-mkdir -p %{buildroot}%{_datadir}/%{name}
+mkdir -p %{buildroot}%{_datadir}/vivante/res
 install -m 755 %{name} %{buildroot}%{_bindir}/%{name}
-install -m 644 res/sample_pizza_299x299 %{buildroot}%{_datadir}/%{name}/sample_pizza_299x299
+install -m 644 res/sample_pizza_299x299 %{buildroot}%{_datadir}/vivante/res/sample_pizza_299x299
 
 %files
 %manifest %{name}.manifest
 %{_bindir}/%{name}
-%{_datadir}/%{name}/sample_pizza_299x299
+%{_datadir}/vivante/res/sample_pizza_299x299
 
 %changelog
 * Thu Feb 20 2020 HyoungJoo Ahn <hello.ahn@samsung.com>


### PR DESCRIPTION
`vivante-nnstreamer-filter-inceptionv3` is not used anymore

Signed-off-by: HyoungJoo Ahn <hello.ahn@samsung.com>

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped