### PR TITLE
[Native/SpeechCommand] Add omitted dimension information for output

### DIFF
--- a/native/example_speech_command_tensorflow_lite/nnscustom_speech_command_tflite.c
+++ b/native/example_speech_command_tensorflow_lite/nnscustom_speech_command_tflite.c
@@ -87,6 +87,8 @@ set_inputDim (void *_data, const GstTensorFilterProperties * prop,
   out_info->info[t].type = _NNS_INT32;
 
   out_info->info[t].dimension[0] = in_info->num_tensors;
+  for (i = 1; i < NNS_TENSOR_RANK_LIMIT; ++i)
+    out_info->info[t].dimension[i] = 1;
 
   return 0;
 }


### PR DESCRIPTION
The dimension information for the second tensor of ouput is not fully filled. This patch fills the dimesion information for the dimensions, 2, 3, and 4.

Signed-off-by: Wook Song <wook16.song@samsung.com>

Resolves: Bug realted to speech_command_tflite in https://github.com/nnsuite/nnstreamer/issues/2145

**Self evaluation:**
1. Build test: [*]Passed [ ]Failed [ ]Skipped
2. Run test: [*]Passed [ ]Failed [ ]Skipped
